### PR TITLE
Set debug log level based on a flag / env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-
 # korp
+
 A command line tool for pushing docker images into a different Docker registry based on given Kubernetes yaml files.
 
 ## Installation
@@ -18,6 +18,7 @@ korp scan -f <path to yaml files> -r <docker registry name>
 ```
 
 `example`
+
 ```
 korp scan -f ./sample-yaml -r
 cat kustomization.yaml
@@ -30,6 +31,7 @@ korp pull -k <path to kustomization.yaml>
 ```
 
 `example`
+
 ```
 korp scan -f ./sample-yaml
 korp pull
@@ -43,6 +45,7 @@ korp pull -k <path to kustomization.yaml>
 ```
 
 `example`
+
 ```
 docker run -d --name registry --restart always -p 5000:5000 registry
 korp scan -f ./sample-yaml -r "localhost:5000"
@@ -82,8 +85,8 @@ korp push
 ### improvements
 
 - [x] rename and split utils package
-- [ ] debug flag / env-var
-  - [ ] using cli framework
+- [x] debug flag / env-var
+  - [x] using cli framework
 - [ ] config file
   - [ ] using cli framework
 
@@ -91,4 +94,4 @@ korp push
 
 ## Issues
 
-* CRD image references not recognized
+- CRD image references not recognized

--- a/main.go
+++ b/main.go
@@ -11,8 +11,10 @@ import (
 
 const (
 	version  = "0.0.1"
-	logLevel = "debug"
+	logLevel = "info"
 )
+
+var debug = false
 
 // main -
 func main() {
@@ -20,6 +22,8 @@ func main() {
 	setLogLevel(logLevel)
 
 	app := createApp()
+	addFlags(app)
+	addBefore(app, &debug)
 	addCommands(app)
 	execApp(app)
 }
@@ -42,6 +46,27 @@ func createApp() *cli.App {
 	app.Usage = "push images to a corporate registry based on Kubernetes yaml files"
 	app.Version = version
 	return app
+}
+
+func addBefore(app *cli.App, debug *bool) {
+	app.Before = func(c *cli.Context) error {
+		if *debug {
+			log.SetLevel(log.DebugLevel)
+		}
+		return nil
+	}
+}
+
+// addFlags - Add global flags to CLI application
+func addFlags(app *cli.App) {
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:        "debug, d",
+			Usage:       "switch on debug log output",
+			EnvVar:      "KORP_LOG_DEBUG",
+			Destination: &debug,
+		},
+	}
 }
 
 // addCommands - Add commands to CLI application


### PR DESCRIPTION
If we do this in the Before routine of the app we don't need to pass down the debug flag to the actions.