### PR TITLE
Add a robust before function to scan to load registry from yaml file

### DIFF
--- a/cli_utils/commands.go
+++ b/cli_utils/commands.go
@@ -2,10 +2,37 @@ package cli_utils
 
 import (
 	"os/exec"
+
+	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"github.com/urfave/cli/altsrc"
 )
 
 // ExecCommand - Execute a command on the current OS
 func ExecCommand(command string, args ...string) ([]byte, error) {
 
 	return exec.Command(command, args...).Output()
+}
+
+// GetFileFlagsBeforeFunc - get flags from a file, being as tolerant as possible
+func GetFileFlagsBeforeFunc(flags []cli.Flag, flagName string) cli.BeforeFunc {
+	return func(context *cli.Context) error {
+		var filepath = context.String(flagName)
+		filepath, err := homedir.Expand(filepath)
+		if err != nil {
+			log.Debugf("Home directory could not be expanded: %s", filepath)
+			return nil
+		}
+		log.Debugf("Home directory expanded: %s", filepath)
+		sourceContext, err := altsrc.NewYamlSourceFromFile(filepath)
+		if err != nil {
+			log.Debugf("Config file not found at %s", filepath)
+			return nil
+		}
+		log.Debugf("Config file found at %s", filepath)
+		log.Debugf("Source context %s", sourceContext)
+		log.Debugf("Flags %s", flags)
+		return altsrc.InitInputSourceWithContext(flags, func(context *cli.Context) (altsrc.InputSourceContext, error) { return sourceContext, nil })(context)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kubernetes-sigs/kustomize v2.0.3+incompatible
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -19,6 +20,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubernetes-sigs/kustomize v2.0.3+incompatible h1:3hC4tnibtc3SVKd6VLMM6GYrRfFMj77Tc5UmdjMa4B0=
 github.com/kubernetes-sigs/kustomize v2.0.3+incompatible/go.mod h1:LEfoFBposdQuHJ4ZX2gdT7eoybOslchqvocZtlLyTsk=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=

--- a/scan/command.go
+++ b/scan/command.go
@@ -1,39 +1,48 @@
 package scan
 
 import (
+	"github.com/swisscom/korp/cli_utils"
 	"github.com/urfave/cli"
 )
 
 // BuildCommand - Build CLI application command
 func BuildCommand() *cli.Command {
 
+	var flags = []cli.Flag{
+		cli.StringFlag{
+			Name:     "files, f",
+			Usage:    "path to yaml files to scan (default: current dir)",
+			EnvVar:   "KORP_SCAN_FILES",
+			Value:    ".",
+			Required: false,
+		},
+		cli.StringFlag{
+			Name:     "registry, r",
+			Usage:    "name of the Docker registry to use (default: 'docker.io')",
+			EnvVar:   "KORP_SCAN_REGISTRY",
+			Required: false,
+		},
+		cli.StringFlag{
+			Name:     "output, o",
+			Usage:    "path of the kustomization file to be written (default: current dir)",
+			EnvVar:   "KORP_SCAN_OUTPUT",
+			Value:    ".",
+			Required: false,
+		},
+		cli.StringFlag{
+			Name:   "config, c",
+			Usage:  "Load configuration from `FILE`",
+			EnvVar: "KORP_SCAN_CONFIG",
+			Value:  "~/.korp/config.yml",
+		},
+	}
+
 	return &cli.Command{
 		Name:    "scan",
 		Aliases: []string{"s"},
 		Usage:   "collect images referenced in all yaml files in the path and create a kustomization file",
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:     "files, f",
-				Usage:    "path to yaml files to scan (default: current dir)",
-				EnvVar:   "KORP_SCAN_FILES",
-				Value:    ".",
-				Required: false,
-			},
-			cli.StringFlag{
-				Name:     "registry, r",
-				Usage:    "name of the Docker registry to use (default: 'docker.io')",
-				EnvVar:   "KORP_SCAN_REGISTRY",
-				Value:    "docker.io",
-				Required: false,
-			},
-			cli.StringFlag{
-				Name:     "output, o",
-				Usage:    "path of the kustomization file to be written (default: current dir)",
-				EnvVar:   "KORP_SCAN_OUTPUT",
-				Value:    ".",
-				Required: false,
-			},
-		},
-		Action: scan,
+		Flags:   flags,
+		Action:  scan,
+		Before:  cli_utils.GetFileFlagsBeforeFunc(flags, "config"),
 	}
 }


### PR DESCRIPTION
I was thinking more in this direction: have a Before function on each command which loads the config file in a tolerant way. Unfortunately, `cli_utils.GetFileFlagsBeforeFunc` doesn't work correctly yet. It doesn't set the flags for some reason.